### PR TITLE
updated URLs to point to rroodll repo

### DIFF
--- a/data/fh_qsvt-128x1280-demo.json
+++ b/data/fh_qsvt-128x1280-demo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json",
+  "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
   "id": "MITLL FH Demo 1",
   "name": "Fermi-Hubbard",
   "category": "scientific",

--- a/qb_reporting/demo_estimates/fh-qet-128x128.json
+++ b/qb_reporting/demo_estimates/fh-qet-128x128.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json",
+  "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
   "id": "FH 128x128 Square (U/J = 4.0)",
   "name": "Fermi-Hubbard",
   "category": "scientific",

--- a/qb_reporting/demo_estimates/fh-qet-16x16.json
+++ b/qb_reporting/demo_estimates/fh-qet-16x16.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json",
+  "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
   "id": "FH 16x16 Square (U/J = 4.0)",
   "name": "Fermi-Hubbard",
   "category": "scientific",

--- a/qb_reporting/demo_estimates/fh-qet-2x2.json
+++ b/qb_reporting/demo_estimates/fh-qet-2x2.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json",
+  "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
   "id": "FH 2x2 Square (U/J = 4.0)",
   "name": "Fermi-Hubbard",
   "category": "scientific",

--- a/qb_reporting/demo_estimates/fh-qet-32x32.json
+++ b/qb_reporting/demo_estimates/fh-qet-32x32.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json",
+  "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
   "id": "FH 32x32 Square (U/J = 4.0)",
   "name": "Fermi-Hubbard",
   "category": "scientific",

--- a/qb_reporting/demo_estimates/fh-qet-4x4.json
+++ b/qb_reporting/demo_estimates/fh-qet-4x4.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json",
+  "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
   "id": "FH 4x4 Square (U/J = 4.0)",
   "name": "Fermi-Hubbard",
   "category": "scientific",

--- a/qb_reporting/demo_estimates/fh-qet-64x64.json
+++ b/qb_reporting/demo_estimates/fh-qet-64x64.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json",
+  "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
   "id": "FH 64x64 Square (U/J = 4.0)",
   "name": "Fermi-Hubbard",
   "category": "scientific",

--- a/qb_reporting/demo_estimates/fh-qet-8x8.json
+++ b/qb_reporting/demo_estimates/fh-qet-8x8.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json",
+  "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
   "id": "FH 8x8 Square (U/J = 4.0)",
   "name": "Fermi-Hubbard",
   "category": "scientific",

--- a/qb_reporting/qb_minimal_reporting_schema.ipynb
+++ b/qb_reporting/qb_minimal_reporting_schema.ipynb
@@ -39,7 +39,16 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/labuser/.local/lib/python3.10/site-packages/matplotlib/projections/__init__.py:63: UserWarning: Unable to import Axes3D. This may be due to multiple versions of Matplotlib being installed (e.g. as a system package and as a pip package). As a result, the 3D projection is not available.\n",
+      "  warnings.warn(\"Unable to import Axes3D. This may be due to multiple versions of \"\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy              as  np\n",
     "import pandas             as  pd\n",
@@ -92,7 +101,7 @@
    "outputs": [],
    "source": [
     "fermi_hubbard_estimate = {\n",
-    "    \"$schema\":               \"https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json\",\n",
+    "    \"$schema\":               \"https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json\",\n",
     "                                                                  # The schema for the JSON object.\n",
     "    \"id\":                    \"MITLL FH Demo 1\",                   # Unique Identifier (REQUIRED, string)\n",
     "    \"name\":                  \"Fermi-Hubbard\",                     # Application name (REQUIRED, string)\n",
@@ -173,7 +182,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/labuser/Projects/fork/QB-Estimate-Reporting/.venv/lib/python3.10/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'raw.githubusercontent.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings\n",
+      "/home/labuser/.local/lib/python3.10/site-packages/urllib3/connectionpool.py:1056: InsecureRequestWarning: Unverified HTTPS request is being made to host 'raw.githubusercontent.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n",
       "  warnings.warn(\n"
      ]
     }
@@ -243,14 +252,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/labuser/Projects/fork/QB-Estimate-Reporting/.venv/lib/python3.10/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'raw.githubusercontent.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings\n",
+      "/home/labuser/.local/lib/python3.10/site-packages/urllib3/connectionpool.py:1056: InsecureRequestWarning: Unverified HTTPS request is being made to host 'raw.githubusercontent.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n",
       "  warnings.warn(\n"
      ]
     }
@@ -268,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -276,7 +285,7 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"$schema\": \"https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json\",\n",
+      "    \"$schema\": \"https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json\",\n",
       "    \"id\": \"MITLL FH Demo 1\",\n",
       "    \"name\": \"Fermi-Hubbard\",\n",
       "    \"category\": \"scientific\",\n",
@@ -349,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -385,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -421,13 +430,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>$schema</th>\n",
-       "      <td>https://raw.githubusercontent.com/jp7745/QB-Es...</td>\n",
-       "      <td>https://raw.githubusercontent.com/jp7745/QB-Es...</td>\n",
-       "      <td>https://raw.githubusercontent.com/jp7745/QB-Es...</td>\n",
-       "      <td>https://raw.githubusercontent.com/jp7745/QB-Es...</td>\n",
-       "      <td>https://raw.githubusercontent.com/jp7745/QB-Es...</td>\n",
-       "      <td>https://raw.githubusercontent.com/jp7745/QB-Es...</td>\n",
-       "      <td>https://raw.githubusercontent.com/jp7745/QB-Es...</td>\n",
+       "      <td>https://raw.githubusercontent.com/rroodll/QB-E...</td>\n",
+       "      <td>https://raw.githubusercontent.com/rroodll/QB-E...</td>\n",
+       "      <td>https://raw.githubusercontent.com/rroodll/QB-E...</td>\n",
+       "      <td>https://raw.githubusercontent.com/rroodll/QB-E...</td>\n",
+       "      <td>https://raw.githubusercontent.com/rroodll/QB-E...</td>\n",
+       "      <td>https://raw.githubusercontent.com/rroodll/QB-E...</td>\n",
+       "      <td>https://raw.githubusercontent.com/rroodll/QB-E...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>id</th>\n",
@@ -595,7 +604,7 @@
       ],
       "text/plain": [
        "                                                                   fh-qet-128x128.json  \\\n",
-       "$schema                              https://raw.githubusercontent.com/jp7745/QB-Es...   \n",
+       "$schema                              https://raw.githubusercontent.com/rroodll/QB-E...   \n",
        "id                                                       FH 128x128 Square (U/J = 4.0)   \n",
        "name                                                                     Fermi-Hubbard   \n",
        "category                                                                    scientific   \n",
@@ -614,7 +623,7 @@
        "clifford_count                                                            310704519223   \n",
        "\n",
        "                                                                       fh-qet-8x8.json  \\\n",
-       "$schema                              https://raw.githubusercontent.com/jp7745/QB-Es...   \n",
+       "$schema                              https://raw.githubusercontent.com/rroodll/QB-E...   \n",
        "id                                                           FH 8x8 Square (U/J = 4.0)   \n",
        "name                                                                     Fermi-Hubbard   \n",
        "category                                                                    scientific   \n",
@@ -633,7 +642,7 @@
        "clifford_count                                                                 7533143   \n",
        "\n",
        "                                                                       fh-qet-2x2.json  \\\n",
-       "$schema                              https://raw.githubusercontent.com/jp7745/QB-Es...   \n",
+       "$schema                              https://raw.githubusercontent.com/rroodll/QB-E...   \n",
        "id                                                           FH 2x2 Square (U/J = 4.0)   \n",
        "name                                                                     Fermi-Hubbard   \n",
        "category                                                                    scientific   \n",
@@ -652,7 +661,7 @@
        "clifford_count                                                                  193111   \n",
        "\n",
        "                                                                     fh-qet-64x64.json  \\\n",
-       "$schema                              https://raw.githubusercontent.com/jp7745/QB-Es...   \n",
+       "$schema                              https://raw.githubusercontent.com/rroodll/QB-E...   \n",
        "id                                                         FH 64x64 Square (U/J = 4.0)   \n",
        "name                                                                     Fermi-Hubbard   \n",
        "category                                                                    scientific   \n",
@@ -671,7 +680,7 @@
        "clifford_count                                                             19591746347   \n",
        "\n",
        "                                                                     fh-qet-16x16.json  \\\n",
-       "$schema                              https://raw.githubusercontent.com/jp7745/QB-Es...   \n",
+       "$schema                              https://raw.githubusercontent.com/rroodll/QB-E...   \n",
        "id                                                         FH 16x16 Square (U/J = 4.0)   \n",
        "name                                                                     Fermi-Hubbard   \n",
        "category                                                                    scientific   \n",
@@ -690,7 +699,7 @@
        "clifford_count                                                                87896587   \n",
        "\n",
        "                                                                       fh-qet-4x4.json  \\\n",
-       "$schema                              https://raw.githubusercontent.com/jp7745/QB-Es...   \n",
+       "$schema                              https://raw.githubusercontent.com/rroodll/QB-E...   \n",
        "id                                                           FH 4x4 Square (U/J = 4.0)   \n",
        "name                                                                     Fermi-Hubbard   \n",
        "category                                                                    scientific   \n",
@@ -709,7 +718,7 @@
        "clifford_count                                                                  940395   \n",
        "\n",
        "                                                                     fh-qet-32x32.json  \n",
-       "$schema                              https://raw.githubusercontent.com/jp7745/QB-Es...  \n",
+       "$schema                              https://raw.githubusercontent.com/rroodll/QB-E...  \n",
        "id                                                         FH 32x32 Square (U/J = 4.0)  \n",
        "name                                                                     Fermi-Hubbard  \n",
        "category                                                                    scientific  \n",
@@ -728,7 +737,7 @@
        "clifford_count                                                               257575242  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -739,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -824,7 +833,7 @@
        "num_qubits              2076  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/schema/resource_estimate_schema.json
+++ b/schema/resource_estimate_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json",
+  "$id": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
   "title": "Resource Estimate Schema",
   "description": "Describes the required fields for a valid resource estimate file.",
   "required": [


### PR DESCRIPTION
schema URLs in the $schema field had to be updated to point to the original rroodll repo.  

found instances of the url:  https://raw.githubusercontent.com/jp7745/QB-Estimate-Reporting/feature/stand-alone-schema-file/schema/resource_estimate_schema.json

and replaced with:  https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json

re-ran notebooks to confirm good.