### PR TITLE
GSEE logical resource estimates

### DIFF
--- a/data/BOBQAT/resource_estimate.gsee.Cr_0.54_orbitals.5d85532e-9116-48a1-9810-7925c9ed9c57.json
+++ b/data/BOBQAT/resource_estimate.gsee.Cr_0.54_orbitals.5d85532e-9116-48a1-9810-7925c9ed9c57.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "5d85532e-9116-48a1-9810-7925c9ed9c57",
+    "name": "Cr_0",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1735,
+        "t_count": 323909060720
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Cr_1.54_orbitals.b24b71b9-971a-4aca-9fc0-7198d16ca9ed.json
+++ b/data/BOBQAT/resource_estimate.gsee.Cr_1.54_orbitals.b24b71b9-971a-4aca-9fc0-7198d16ca9ed.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b24b71b9-971a-4aca-9fc0-7198d16ca9ed",
+    "name": "Cr_1",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1735,
+        "t_count": 315828734064
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Cu_0.54_orbitals.7f0518e8-e2c8-4912-8268-4de4cd504084.json
+++ b/data/BOBQAT/resource_estimate.gsee.Cu_0.54_orbitals.7f0518e8-e2c8-4912-8268-4de4cd504084.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "7f0518e8-e2c8-4912-8268-4de4cd504084",
+    "name": "Cu_0",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 37,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 37,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1792,
+        "t_count": 1014336850272
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Cu_1.54_orbitals.5f5fee92-5821-4d38-a54a-d204660f205f.json
+++ b/data/BOBQAT/resource_estimate.gsee.Cu_1.54_orbitals.5f5fee92-5821-4d38-a54a-d204660f205f.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "5f5fee92-5821-4d38-a54a-d204660f205f",
+    "name": "Cu_1",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1790,
+        "t_count": 245556316272
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Fe_0.54_orbitals.5b8f4746-a08b-4ec5-92e2-ce55cc2fdb75.json
+++ b/data/BOBQAT/resource_estimate.gsee.Fe_0.54_orbitals.5b8f4746-a08b-4ec5-92e2-ce55cc2fdb75.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "5b8f4746-a08b-4ec5-92e2-ce55cc2fdb75",
+    "name": "Fe_0",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1735,
+        "t_count": 362544892016
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Fe_1.54_orbitals.a7e26b10-bd6b-457c-978e-9050f6529007.json
+++ b/data/BOBQAT/resource_estimate.gsee.Fe_1.54_orbitals.a7e26b10-bd6b-457c-978e-9050f6529007.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "a7e26b10-bd6b-457c-978e-9050f6529007",
+    "name": "Fe_1",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1735,
+        "t_count": 352593905776
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Mn_0.54_orbitals.289f5dfe-e6d5-48a3-a6ae-25088321d3c6.json
+++ b/data/BOBQAT/resource_estimate.gsee.Mn_0.54_orbitals.289f5dfe-e6d5-48a3-a6ae-25088321d3c6.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "289f5dfe-e6d5-48a3-a6ae-25088321d3c6",
+    "name": "Mn_0",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 8,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 8,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1735,
+        "t_count": 350270261360
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Mn_1.54_orbitals.9d82f7d4-165d-4499-8add-361a770d1d44.json
+++ b/data/BOBQAT/resource_estimate.gsee.Mn_1.54_orbitals.9d82f7d4-165d-4499-8add-361a770d1d44.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "9d82f7d4-165d-4499-8add-361a770d1d44",
+    "name": "Mn_1",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1734,
+        "t_count": 148560021496
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.O_0.22_orbitals.402d5237-16a3-4eb8-8bd4-5dcf2cb14c36.json
+++ b/data/BOBQAT/resource_estimate.gsee.O_0.22_orbitals.402d5237-16a3-4eb8-8bd4-5dcf2cb14c36.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "402d5237-16a3-4eb8-8bd4-5dcf2cb14c36",
+    "name": "O_0",
+    "category": "industrial",
+    "size": "22_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 715,
+        "t_count": 3995567520
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.O_0.45_orbitals.85a3a8d6-f2c7-458c-bbc3-25fd76d9afc0.json
+++ b/data/BOBQAT/resource_estimate.gsee.O_0.45_orbitals.85a3a8d6-f2c7-458c-bbc3-25fd76d9afc0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "85a3a8d6-f2c7-458c-bbc3-25fd76d9afc0",
+    "name": "O_0",
+    "category": "industrial",
+    "size": "45_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1470,
+        "t_count": 129007093872
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.O_1.22_orbitals.752966e5-7de7-4506-82ae-6b22cd54b1c1.json
+++ b/data/BOBQAT/resource_estimate.gsee.O_1.22_orbitals.752966e5-7de7-4506-82ae-6b22cd54b1c1.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "752966e5-7de7-4506-82ae-6b22cd54b1c1",
+    "name": "O_1",
+    "category": "industrial",
+    "size": "22_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 2,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 715,
+        "t_count": 4116415904
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.O_1.45_orbitals.f9bdbb3b-91b6-43f3-93ca-bef1e10d3835.json
+++ b/data/BOBQAT/resource_estimate.gsee.O_1.45_orbitals.f9bdbb3b-91b6-43f3-93ca-bef1e10d3835.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "f9bdbb3b-91b6-43f3-93ca-bef1e10d3835",
+    "name": "O_1",
+    "category": "industrial",
+    "size": "45_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 2,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1472,
+        "t_count": 73244477432
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Sc_0.54_orbitals.fb87d637-aaab-4e8f-8898-4ecca8bd0fe0.json
+++ b/data/BOBQAT/resource_estimate.gsee.Sc_0.54_orbitals.fb87d637-aaab-4e8f-8898-4ecca8bd0fe0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "fb87d637-aaab-4e8f-8898-4ecca8bd0fe0",
+    "name": "Sc_0",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1732,
+        "t_count": 227955968112
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Sc_1.54_orbitals.ca6f7678-0952-4fe4-83fe-c4455a682132.json
+++ b/data/BOBQAT/resource_estimate.gsee.Sc_1.54_orbitals.ca6f7678-0952-4fe4-83fe-c4455a682132.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "ca6f7678-0952-4fe4-83fe-c4455a682132",
+    "name": "Sc_1",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1732,
+        "t_count": 231531612272
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Ti_0.54_orbitals.ab61c91a-68ea-401f-a3ad-392e83ee802e.json
+++ b/data/BOBQAT/resource_estimate.gsee.Ti_0.54_orbitals.ab61c91a-68ea-401f-a3ad-392e83ee802e.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "ab61c91a-68ea-401f-a3ad-392e83ee802e",
+    "name": "Ti_0",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 74,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 74,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1737,
+        "t_count": 1400250567008
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.Ti_1.54_orbitals.2cd76a23-0514-458a-b588-94e2d10564d3.json
+++ b/data/BOBQAT/resource_estimate.gsee.Ti_1.54_orbitals.2cd76a23-0514-458a-b588-94e2d10564d3.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "2cd76a23-0514-458a-b588-94e2d10564d3",
+    "name": "Ti_1",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 8,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 8,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1735,
+        "t_count": 350293330032
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.V_0.54_orbitals.0f0c8766-4bf5-4c1e-991a-9dafe9bc8f27.json
+++ b/data/BOBQAT/resource_estimate.gsee.V_0.54_orbitals.0f0c8766-4bf5-4c1e-991a-9dafe9bc8f27.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "0f0c8766-4bf5-4c1e-991a-9dafe9bc8f27",
+    "name": "V_0",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 32,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 32,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1736,
+        "t_count": 672883280104
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.V_1.54_orbitals.6d0f8edd-507f-43d5-9960-9ad49532ee42.json
+++ b/data/BOBQAT/resource_estimate.gsee.V_1.54_orbitals.6d0f8edd-507f-43d5-9960-9ad49532ee42.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "6d0f8edd-507f-43d5-9960-9ad49532ee42",
+    "name": "V_1",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 25,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 25,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1736,
+        "t_count": 559825815784
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.be_0.30_orbitals.543e2ed4-a12d-495b-a246-1e4d905ad4a3.json
+++ b/data/BOBQAT/resource_estimate.gsee.be_0.30_orbitals.543e2ed4-a12d-495b-a246-1e4d905ad4a3.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "543e2ed4-a12d-495b-a246-1e4d905ad4a3",
+    "name": "be_0",
+    "category": "industrial",
+    "size": "30_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 961,
+        "t_count": 14775813760
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.be_0.55_orbitals.afdc2f74-eb52-41ae-b72a-30e5a4c07013.json
+++ b/data/BOBQAT/resource_estimate.gsee.be_0.55_orbitals.afdc2f74-eb52-41ae-b72a-30e5a4c07013.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "afdc2f74-eb52-41ae-b72a-30e5a4c07013",
+    "name": "be_0",
+    "category": "industrial",
+    "size": "55_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1766,
+        "t_count": 290167982192
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.benzene.30_orbitals.b86457a4-abf4-43c9-9c08-2397e95b7c0f.json
+++ b/data/BOBQAT/resource_estimate.gsee.benzene.30_orbitals.b86457a4-abf4-43c9-9c08-2397e95b7c0f.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b86457a4-abf4-43c9-9c08-2397e95b7c0f",
+    "name": "benzene",
+    "category": "industrial",
+    "size": "30_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 582,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 582,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 933,
+        "t_count": 160080332728
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.18_orbitals.950da653-13ce-4cd7-95d8-5045ab03d4bc.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.18_orbitals.950da653-13ce-4cd7-95d8-5045ab03d4bc.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "950da653-13ce-4cd7-95d8-5045ab03d4bc",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "18_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.120203954,
+    "value_ci": [
+        0.087628683,
+        0.087628683
+    ],
+    "circuit_repetitions_per_calculation": 21,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 21,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 549,
+        "t_count": 3840902560
+    },
+    "value_per_t_gate": 1.4902741530427706e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.18_orbitals.9da97ef6-4bad-4c82-8576-9b8e539a7ba8.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.18_orbitals.9da97ef6-4bad-4c82-8576-9b8e539a7ba8.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "9da97ef6-4bad-4c82-8576-9b8e539a7ba8",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "18_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.027348021,
+    "value_ci": [
+        0.021709741,
+        0.021709741
+    ],
+    "circuit_repetitions_per_calculation": 9,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 9,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 548,
+        "t_count": 1916519744
+    },
+    "value_per_t_gate": 1.5855140598019322e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.19_orbitals.1a013e9f-7eab-4a1b-b486-1d9e2d99e754.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.19_orbitals.1a013e9f-7eab-4a1b-b486-1d9e2d99e754.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "1a013e9f-7eab-4a1b-b486-1d9e2d99e754",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "19_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.088744857,
+    "value_ci": [
+        0.075842705,
+        0.075842705
+    ],
+    "circuit_repetitions_per_calculation": 16,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 16,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 591,
+        "t_count": 4358505888
+    },
+    "value_per_t_gate": 1.2725814086361513e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.22_orbitals.13821f5c-78a6-485c-9006-a17a234cde9f.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.22_orbitals.13821f5c-78a6-485c-9006-a17a234cde9f.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "13821f5c-78a6-485c-9006-a17a234cde9f",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "22_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 1.574957895,
+    "value_ci": [
+        1.449781333,
+        1.449781333
+    ],
+    "circuit_repetitions_per_calculation": 72,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 72,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 669,
+        "t_count": 12539069952
+    },
+    "value_per_t_gate": 1.7445006122518945e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.22_orbitals.f20db1b1-86e3-4ddf-96ff-a6d37f331935.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.22_orbitals.f20db1b1-86e3-4ddf-96ff-a6d37f331935.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "f20db1b1-86e3-4ddf-96ff-a6d37f331935",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "22_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.074677796,
+    "value_ci": [
+        0.059791223,
+        0.059791223
+    ],
+    "circuit_repetitions_per_calculation": 13,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 13,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 668,
+        "t_count": 6263506336
+    },
+    "value_per_t_gate": 9.171294061182931e-13
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.28_orbitals.001a0d11-165a-49c5-a334-643023029f40.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.28_orbitals.001a0d11-165a-49c5-a334-643023029f40.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "001a0d11-165a-49c5-a334-643023029f40",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "28_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 7.042062432,
+    "value_ci": [
+        6.564503087,
+        6.564503087
+    ],
+    "circuit_repetitions_per_calculation": 22,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 22,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 846,
+        "t_count": 23530899072
+    },
+    "value_per_t_gate": 1.3603124382526394e-11
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.34_orbitals.1c9508e3-b9fe-44f1-ae58-c6339ef43f47.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.34_orbitals.1c9508e3-b9fe-44f1-ae58-c6339ef43f47.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "1c9508e3-b9fe-44f1-ae58-c6339ef43f47",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "34_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 3473.212775,
+    "value_ci": [
+        2991.984565,
+        2991.984565
+    ],
+    "circuit_repetitions_per_calculation": 63,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 63,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1041,
+        "t_count": 80542042104
+    },
+    "value_per_t_gate": 6.844917271497707e-10
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.34_orbitals.742be33c-0982-4b06-b324-1d86242e28d9.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.34_orbitals.742be33c-0982-4b06-b324-1d86242e28d9.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "742be33c-0982-4b06-b324-1d86242e28d9",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "34_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 9040.268201,
+    "value_ci": [
+        6324.880327,
+        6324.880327
+    ],
+    "circuit_repetitions_per_calculation": 106,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 106,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1042,
+        "t_count": 161505609840
+    },
+    "value_per_t_gate": 5.280655523391926e-10
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.34_orbitals.765594e5-44ac-41a2-89a7-f2ac03536379.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.34_orbitals.765594e5-44ac-41a2-89a7-f2ac03536379.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "765594e5-44ac-41a2-89a7-f2ac03536379",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "34_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 1403038.085,
+    "value_ci": [
+        960831.226,
+        960831.226
+    ],
+    "circuit_repetitions_per_calculation": 124,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 124,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1042,
+        "t_count": 158320035952
+    },
+    "value_per_t_gate": 7.146804381448915e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.36_orbitals.3b49563d-948a-4ecb-84a0-d3c0c2c0d217.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.36_orbitals.3b49563d-948a-4ecb-84a0-d3c0c2c0d217.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "3b49563d-948a-4ecb-84a0-d3c0c2c0d217",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "36_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 554332.4386,
+    "value_ci": [
+        511968.2041,
+        511968.2041
+    ],
+    "circuit_repetitions_per_calculation": 211,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 211,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1094,
+        "t_count": 187860519024
+    },
+    "value_per_t_gate": 1.398467314526372e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.36_orbitals.6713517a-ab65-4381-aae1-0839dcd6c1a0.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.36_orbitals.6713517a-ab65-4381-aae1-0839dcd6c1a0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "6713517a-ab65-4381-aae1-0839dcd6c1a0",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "36_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 46422.61952,
+    "value_ci": [
+        29079.06049,
+        29079.06049
+    ],
+    "circuit_repetitions_per_calculation": 55,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 55,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1093,
+        "t_count": 94735566840
+    },
+    "value_per_t_gate": 8.909511557173511e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.blue_dimer.36_orbitals.858b9683-fc6c-4ebe-8c33-27f0d848f24f.json
+++ b/data/BOBQAT/resource_estimate.gsee.blue_dimer.36_orbitals.858b9683-fc6c-4ebe-8c33-27f0d848f24f.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "858b9683-fc6c-4ebe-8c33-27f0d848f24f",
+    "name": "blue_dimer",
+    "category": "industrial",
+    "size": "36_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 3455982.477,
+    "value_ci": [
+        2510695.678,
+        2510695.678
+    ],
+    "circuit_repetitions_per_calculation": 212,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 212,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1094,
+        "t_count": 186566576240
+    },
+    "value_per_t_gate": 8.737794553201076e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.c2_h2_0.38_orbitals.2761e36e-f001-42af-8086-f507b5643ec8.json
+++ b/data/BOBQAT/resource_estimate.gsee.c2_h2_0.38_orbitals.2761e36e-f001-42af-8086-f507b5643ec8.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "2761e36e-f001-42af-8086-f507b5643ec8",
+    "name": "c2_h2_0",
+    "category": "industrial",
+    "size": "38_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 16,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 16,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1222,
+        "t_count": 50116822896
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c2_h4_0.48_orbitals.26423f2e-e3e1-4bbb-b2ff-52bdae87d65b.json
+++ b/data/BOBQAT/resource_estimate.gsee.c2_h4_0.48_orbitals.26423f2e-e3e1-4bbb-b2ff-52bdae87d65b.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "26423f2e-e3e1-4bbb-b2ff-52bdae87d65b",
+    "name": "c2_h4_0",
+    "category": "industrial",
+    "size": "48_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 25,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 25,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1510,
+        "t_count": 227974842480
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c2_h6_0.58_orbitals.15a25e30-cba9-4f63-80a6-ef95a8c79d41.json
+++ b/data/BOBQAT/resource_estimate.gsee.c2_h6_0.58_orbitals.15a25e30-cba9-4f63-80a6-ef95a8c79d41.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "15a25e30-cba9-4f63-80a6-ef95a8c79d41",
+    "name": "c2_h6_0",
+    "category": "industrial",
+    "size": "58_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 14,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 14,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1854,
+        "t_count": 519118784768
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c_h2_singlet_0.24_orbitals.5f0ac7ac-1dcc-46a6-bfa0-6e76c73a0bdd.json
+++ b/data/BOBQAT/resource_estimate.gsee.c_h2_singlet_0.24_orbitals.5f0ac7ac-1dcc-46a6-bfa0-6e76c73a0bdd.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "5f0ac7ac-1dcc-46a6-bfa0-6e76c73a0bdd",
+    "name": "c_h2_singlet_0",
+    "category": "industrial",
+    "size": "24_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 771,
+        "t_count": 11250763392
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c_h2_singlet_0.58_orbitals.8fa0ddcf-9b98-4144-8250-522f38c28b02.json
+++ b/data/BOBQAT/resource_estimate.gsee.c_h2_singlet_0.58_orbitals.8fa0ddcf-9b98-4144-8250-522f38c28b02.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "8fa0ddcf-9b98-4144-8250-522f38c28b02",
+    "name": "c_h2_singlet_0",
+    "category": "industrial",
+    "size": "58_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1913,
+        "t_count": 382867867904
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c_h3_cl_0.47_orbitals.0667179a-19eb-44b9-a544-dae8793fdc3f.json
+++ b/data/BOBQAT/resource_estimate.gsee.c_h3_cl_0.47_orbitals.0667179a-19eb-44b9-a544-dae8793fdc3f.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "0667179a-19eb-44b9-a544-dae8793fdc3f",
+    "name": "c_h3_cl_0",
+    "category": "industrial",
+    "size": "47_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 17,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 17,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1483,
+        "t_count": 274471848048
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c_h4_0.34_orbitals.443371ce-c80d-450d-b281-ac1c4d5ecc4d.json
+++ b/data/BOBQAT/resource_estimate.gsee.c_h4_0.34_orbitals.443371ce-c80d-450d-b281-ac1c4d5ecc4d.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "443371ce-c80d-450d-b281-ac1c4d5ecc4d",
+    "name": "c_h4_0",
+    "category": "industrial",
+    "size": "34_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 9,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 9,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1074,
+        "t_count": 64017794928
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c_o2_0.42_orbitals.615c9d78-2b84-4c7b-ab6b-ba05b188f50a.json
+++ b/data/BOBQAT/resource_estimate.gsee.c_o2_0.42_orbitals.615c9d78-2b84-4c7b-ab6b-ba05b188f50a.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "615c9d78-2b84-4c7b-ab6b-ba05b188f50a",
+    "name": "c_o2_0",
+    "category": "industrial",
+    "size": "42_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 64,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 64,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1340,
+        "t_count": 260671277288
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c_o_0.28_orbitals.02588640-a5ae-48e6-b28b-f6759886ab70.json
+++ b/data/BOBQAT/resource_estimate.gsee.c_o_0.28_orbitals.02588640-a5ae-48e6-b28b-f6759886ab70.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "02588640-a5ae-48e6-b28b-f6759886ab70",
+    "name": "c_o_0",
+    "category": "industrial",
+    "size": "28_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 37,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 37,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 909,
+        "t_count": 53283653456
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c_o_0.60_orbitals.a92f6594-5ccc-4385-9cb5-8c21b4407dcf.json
+++ b/data/BOBQAT/resource_estimate.gsee.c_o_0.60_orbitals.a92f6594-5ccc-4385-9cb5-8c21b4407dcf.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "a92f6594-5ccc-4385-9cb5-8c21b4407dcf",
+    "name": "c_o_0",
+    "category": "industrial",
+    "size": "60_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 67,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 67,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1975,
+        "t_count": 1494335097344
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c_s_0.32_orbitals.886855d3-f1a7-4004-a736-417360e81d0a.json
+++ b/data/BOBQAT/resource_estimate.gsee.c_s_0.32_orbitals.886855d3-f1a7-4004-a736-417360e81d0a.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "886855d3-f1a7-4004-a736-417360e81d0a",
+    "name": "c_s_0",
+    "category": "industrial",
+    "size": "32_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 15,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 15,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1019,
+        "t_count": 44627003112
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.c_s_0.64_orbitals.57830810-1133-4c19-9a19-30183dd86a9f.json
+++ b/data/BOBQAT/resource_estimate.gsee.c_s_0.64_orbitals.57830810-1133-4c19-9a19-30183dd86a9f.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "57830810-1133-4c19-9a19-30183dd86a9f",
+    "name": "c_s_0",
+    "category": "industrial",
+    "size": "64_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 19,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 19,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2097,
+        "t_count": 1176798497152
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.cl2_0.36_orbitals.c01649e2-8c5c-4827-a037-1ede2159e558.json
+++ b/data/BOBQAT/resource_estimate.gsee.cl2_0.36_orbitals.c01649e2-8c5c-4827-a037-1ede2159e558.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "c01649e2-8c5c-4827-a037-1ede2159e558",
+    "name": "cl2_0",
+    "category": "industrial",
+    "size": "36_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 12,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 12,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1167,
+        "t_count": 114299242464
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.cl2_0.68_orbitals.35e4c771-0f4f-4413-b42f-132f1e606cb0.json
+++ b/data/BOBQAT/resource_estimate.gsee.cl2_0.68_orbitals.35e4c771-0f4f-4413-b42f-132f1e606cb0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "35e4c771-0f4f-4413-b42f-132f1e606cb0",
+    "name": "cl2_0",
+    "category": "industrial",
+    "size": "68_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 12,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 12,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2220,
+        "t_count": 1251274656280
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.cr_dimer.18_orbitals.202e6184-1e7d-4c02-a82a-f588b6abf809.json
+++ b/data/BOBQAT/resource_estimate.gsee.cr_dimer.18_orbitals.202e6184-1e7d-4c02-a82a-f588b6abf809.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "202e6184-1e7d-4c02-a82a-f588b6abf809",
+    "name": "cr_dimer",
+    "category": "industrial",
+    "size": "18_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 1316,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 1316,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 574,
+        "t_count": 24212408000
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.cr_dimer.18_orbitals.61ad4cfe-b057-4dd8-bd06-ed56347745c1.json
+++ b/data/BOBQAT/resource_estimate.gsee.cr_dimer.18_orbitals.61ad4cfe-b057-4dd8-bd06-ed56347745c1.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "61ad4cfe-b057-4dd8-bd06-ed56347745c1",
+    "name": "cr_dimer",
+    "category": "industrial",
+    "size": "18_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 2904,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2904,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 575,
+        "t_count": 47401404192
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.cr_dimer.18_orbitals.9030e9c9-0323-413c-a98e-aba16b180ba7.json
+++ b/data/BOBQAT/resource_estimate.gsee.cr_dimer.18_orbitals.9030e9c9-0323-413c-a98e-aba16b180ba7.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "9030e9c9-0323-413c-a98e-aba16b180ba7",
+    "name": "cr_dimer",
+    "category": "industrial",
+    "size": "18_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 689,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 689,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 574,
+        "t_count": 23031711424
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.cr_dimer.26_orbitals.7c8f0a36-cda5-4b33-bb46-4e58a15b37a1.json
+++ b/data/BOBQAT/resource_estimate.gsee.cr_dimer.26_orbitals.7c8f0a36-cda5-4b33-bb46-4e58a15b37a1.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "7c8f0a36-cda5-4b33-bb46-4e58a15b37a1",
+    "name": "cr_dimer",
+    "category": "industrial",
+    "size": "26_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 435,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 435,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 826,
+        "t_count": 104417724344
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.cr_dimer.26_orbitals.c7c653b0-4440-4a36-a66b-8b81a9a351c7.json
+++ b/data/BOBQAT/resource_estimate.gsee.cr_dimer.26_orbitals.c7c653b0-4440-4a36-a66b-8b81a9a351c7.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "c7c653b0-4440-4a36-a66b-8b81a9a351c7",
+    "name": "cr_dimer",
+    "category": "industrial",
+    "size": "26_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 5090,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5090,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 827,
+        "t_count": 222760536096
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.cr_dimer.26_orbitals.fc25a232-d249-4e1c-a9ec-360cab33f779.json
+++ b/data/BOBQAT/resource_estimate.gsee.cr_dimer.26_orbitals.fc25a232-d249-4e1c-a9ec-360cab33f779.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "fc25a232-d249-4e1c-a9ec-360cab33f779",
+    "name": "cr_dimer",
+    "category": "industrial",
+    "size": "26_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7745,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7745,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 828,
+        "t_count": 450453571720
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.f2_0.28_orbitals.94fc2317-29af-43a1-aaec-dade9850ca27.json
+++ b/data/BOBQAT/resource_estimate.gsee.f2_0.28_orbitals.94fc2317-29af-43a1-aaec-dade9850ca27.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "94fc2317-29af-43a1-aaec-dade9850ca27",
+    "name": "f2_0",
+    "category": "industrial",
+    "size": "28_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 10,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 10,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 908,
+        "t_count": 27556185832
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.f2_0.60_orbitals.3fb371ad-c738-40ae-b9ae-80e5bce8f2ac.json
+++ b/data/BOBQAT/resource_estimate.gsee.f2_0.60_orbitals.3fb371ad-c738-40ae-b9ae-80e5bce8f2ac.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "3fb371ad-c738-40ae-b9ae-80e5bce8f2ac",
+    "name": "f2_0",
+    "category": "industrial",
+    "size": "60_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 12,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 12,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1977,
+        "t_count": 1615332379136
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.fe_red.44_orbitals.adecdd92-73c7-416d-90da-b7a3da7ed50b.json
+++ b/data/BOBQAT/resource_estimate.gsee.fe_red.44_orbitals.adecdd92-73c7-416d-90da-b7a3da7ed50b.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "adecdd92-73c7-416d-90da-b7a3da7ed50b",
+    "name": "fe_red",
+    "category": "industrial",
+    "size": "44_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 1856.323858,
+    "value_ci": [
+        1578.193669,
+        1578.193669
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1349,
+        "t_count": 73853503360
+    },
+    "value_per_t_gate": 5.0270434672579356e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.fe_red.44_orbitals.d3bcc63c-57ad-4346-8290-e36447186440.json
+++ b/data/BOBQAT/resource_estimate.gsee.fe_red.44_orbitals.d3bcc63c-57ad-4346-8290-e36447186440.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "d3bcc63c-57ad-4346-8290-e36447186440",
+    "name": "fe_red",
+    "category": "industrial",
+    "size": "44_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 18201.94562,
+    "value_ci": [
+        16170.95333,
+        16170.95333
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1349,
+        "t_count": 74223126400
+    },
+    "value_per_t_gate": 6.130820171164333e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.fe_red.45_orbitals.4970c526-817f-4c04-8d7e-797526d5948d.json
+++ b/data/BOBQAT/resource_estimate.gsee.fe_red.45_orbitals.4970c526-817f-4c04-8d7e-797526d5948d.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "4970c526-817f-4c04-8d7e-797526d5948d",
+    "name": "fe_red",
+    "category": "industrial",
+    "size": "45_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 599.3767919,
+    "value_ci": [
+        456.4348718,
+        456.4348718
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1376,
+        "t_count": 77736642432
+    },
+    "value_per_t_gate": 1.927587728092012e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.fe_red.53_orbitals.d27fb590-4e90-4d5a-bdb8-37fbf22f528b.json
+++ b/data/BOBQAT/resource_estimate.gsee.fe_red.53_orbitals.d27fb590-4e90-4d5a-bdb8-37fbf22f528b.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "d27fb590-4e90-4d5a-bdb8-37fbf22f528b",
+    "name": "fe_red",
+    "category": "industrial",
+    "size": "53_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 20376.09805,
+    "value_ci": [
+        15153.1541,
+        15153.1541
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1648,
+        "t_count": 238949632128
+    },
+    "value_per_t_gate": 2.131840282462224e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.fe_red.54_orbitals.03c70feb-49b8-4113-831a-05e3ae55c66b.json
+++ b/data/BOBQAT/resource_estimate.gsee.fe_red.54_orbitals.03c70feb-49b8-4113-831a-05e3ae55c66b.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "03c70feb-49b8-4113-831a-05e3ae55c66b",
+    "name": "fe_red",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 41279.1809,
+    "value_ci": [
+        16544.3923,
+        16544.3923
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1679,
+        "t_count": 255916116096
+    },
+    "value_per_t_gate": 3.2259930738019823e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.fe_red.54_orbitals.41907f9f-923d-49e3-80a9-519962110ae7.json
+++ b/data/BOBQAT/resource_estimate.gsee.fe_red.54_orbitals.41907f9f-923d-49e3-80a9-519962110ae7.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "41907f9f-923d-49e3-80a9-519962110ae7",
+    "name": "fe_red",
+    "category": "industrial",
+    "size": "54_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 18051.38101,
+    "value_ci": [
+        10895.25258,
+        10895.25258
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1681,
+        "t_count": 255679137920
+    },
+    "value_per_t_gate": 1.4120339388541068e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.fe_red.55_orbitals.0e936335-6370-4587-92f0-02eafaf650ed.json
+++ b/data/BOBQAT/resource_estimate.gsee.fe_red.55_orbitals.0e936335-6370-4587-92f0-02eafaf650ed.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "0e936335-6370-4587-92f0-02eafaf650ed",
+    "name": "fe_red",
+    "category": "industrial",
+    "size": "55_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 18813.43569,
+    "value_ci": [
+        14067.28731,
+        14067.28731
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1707,
+        "t_count": 265221703808
+    },
+    "value_per_t_gate": 1.4186950328634848e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.fe_red.55_orbitals.ad9ceeaf-d7be-46b7-95a9-15bfd33f5022.json
+++ b/data/BOBQAT/resource_estimate.gsee.fe_red.55_orbitals.ad9ceeaf-d7be-46b7-95a9-15bfd33f5022.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "ad9ceeaf-d7be-46b7-95a9-15bfd33f5022",
+    "name": "fe_red",
+    "category": "industrial",
+    "size": "55_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 195960.3597,
+    "value_ci": [
+        114004.1423,
+        114004.1423
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1707,
+        "t_count": 266003941504
+    },
+    "value_per_t_gate": 1.4733643313105063e-07
+}

--- a/data/BOBQAT/resource_estimate.gsee.fe_red.58_orbitals.a7cd2501-2f67-4fcd-b428-f6620f3596fe.json
+++ b/data/BOBQAT/resource_estimate.gsee.fe_red.58_orbitals.a7cd2501-2f67-4fcd-b428-f6620f3596fe.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "a7cd2501-2f67-4fcd-b428-f6620f3596fe",
+    "name": "fe_red",
+    "category": "industrial",
+    "size": "58_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 17758.89578,
+    "value_ci": [
+        13533.87283,
+        13533.87283
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1791,
+        "t_count": 308661586048
+    },
+    "value_per_t_gate": 1.1507033322402685e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.h2_c_o_0.38_orbitals.d58cb72b-e144-4164-aec0-309aaef6394c.json
+++ b/data/BOBQAT/resource_estimate.gsee.h2_c_o_0.38_orbitals.d58cb72b-e144-4164-aec0-309aaef6394c.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "d58cb72b-e144-4164-aec0-309aaef6394c",
+    "name": "h2_c_o_0",
+    "category": "industrial",
+    "size": "38_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 21,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 21,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1225,
+        "t_count": 121723684976
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h2_o2_0.38_orbitals.85743547-31ba-48ff-b854-220e4b9b620f.json
+++ b/data/BOBQAT/resource_estimate.gsee.h2_o2_0.38_orbitals.85743547-31ba-48ff-b854-220e4b9b620f.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "85743547-31ba-48ff-b854-220e4b9b620f",
+    "name": "h2_o2_0",
+    "category": "industrial",
+    "size": "38_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 18,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 18,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1228,
+        "t_count": 162651703408
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h2_o_0.24_orbitals.80d75334-b878-41ec-99a8-b21277f3df60.json
+++ b/data/BOBQAT/resource_estimate.gsee.h2_o_0.24_orbitals.80d75334-b878-41ec-99a8-b21277f3df60.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "80d75334-b878-41ec-99a8-b21277f3df60",
+    "name": "h2_o_0",
+    "category": "industrial",
+    "size": "24_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 773,
+        "t_count": 11467294336
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h2_o_0.58_orbitals.4e395cc5-b5d2-4b82-95a2-1276262386c8.json
+++ b/data/BOBQAT/resource_estimate.gsee.h2_o_0.58_orbitals.4e395cc5-b5d2-4b82-95a2-1276262386c8.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "4e395cc5-b5d2-4b82-95a2-1276262386c8",
+    "name": "h2_o_0",
+    "category": "industrial",
+    "size": "58_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1914,
+        "t_count": 771330935168
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h2_s_0.28_orbitals.f2f09d9f-8328-4d4a-ba91-089f9e56bf0d.json
+++ b/data/BOBQAT/resource_estimate.gsee.h2_s_0.28_orbitals.f2f09d9f-8328-4d4a-ba91-089f9e56bf0d.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "f2f09d9f-8328-4d4a-ba91-089f9e56bf0d",
+    "name": "h2_s_0",
+    "category": "industrial",
+    "size": "28_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 9,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 9,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 877,
+        "t_count": 14710015616
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h2_s_0.62_orbitals.ec0baf59-05f5-49df-b5e5-8f887d822a10.json
+++ b/data/BOBQAT/resource_estimate.gsee.h2_s_0.62_orbitals.ec0baf59-05f5-49df-b5e5-8f887d822a10.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "ec0baf59-05f5-49df-b5e5-8f887d822a10",
+    "name": "h2_s_0",
+    "category": "industrial",
+    "size": "62_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 9,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 9,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2034,
+        "t_count": 851752520064
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h3_c_o_h_0.48_orbitals.fc3586af-0290-4a4a-81e1-422a1d331a09.json
+++ b/data/BOBQAT/resource_estimate.gsee.h3_c_o_h_0.48_orbitals.fc3586af-0290-4a4a-81e1-422a1d331a09.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "fc3586af-0290-4a4a-81e1-422a1d331a09",
+    "name": "h3_c_o_h_0",
+    "category": "industrial",
+    "size": "48_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 20,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 20,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1510,
+        "t_count": 247534979184
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h3_c_s_h_0.52_orbitals.ff159145-fd97-486b-bf16-fc766b362ea3.json
+++ b/data/BOBQAT/resource_estimate.gsee.h3_c_s_h_0.52_orbitals.ff159145-fd97-486b-bf16-fc766b362ea3.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "ff159145-fd97-486b-bf16-fc766b362ea3",
+    "name": "h3_c_s_h_0",
+    "category": "industrial",
+    "size": "52_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 21,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 21,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1675,
+        "t_count": 315814054000
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h_c_n_0.33_orbitals.94db0c2c-89f6-4c3d-b886-a3a6a2bdad1d.json
+++ b/data/BOBQAT/resource_estimate.gsee.h_c_n_0.33_orbitals.94db0c2c-89f6-4c3d-b886-a3a6a2bdad1d.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "94db0c2c-89f6-4c3d-b886-a3a6a2bdad1d",
+    "name": "h_c_n_0",
+    "category": "industrial",
+    "size": "33_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 55,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 55,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1050,
+        "t_count": 79714060256
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h_cl_0.23_orbitals.fa3bc2a8-8067-4088-909a-2ddfa655ebfb.json
+++ b/data/BOBQAT/resource_estimate.gsee.h_cl_0.23_orbitals.fa3bc2a8-8067-4088-909a-2ddfa655ebfb.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "fa3bc2a8-8067-4088-909a-2ddfa655ebfb",
+    "name": "h_cl_0",
+    "category": "industrial",
+    "size": "23_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 742,
+        "t_count": 9130673664
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h_cl_0.48_orbitals.f0637f33-3c53-4f01-8cf7-cfd9c6f39a51.json
+++ b/data/BOBQAT/resource_estimate.gsee.h_cl_0.48_orbitals.f0637f33-3c53-4f01-8cf7-cfd9c6f39a51.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "f0637f33-3c53-4f01-8cf7-cfd9c6f39a51",
+    "name": "h_cl_0",
+    "category": "industrial",
+    "size": "48_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1558,
+        "t_count": 202590914672
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h_f_0.19_orbitals.b59bd259-4941-4cec-bca5-e2795c35d8e0.json
+++ b/data/BOBQAT/resource_estimate.gsee.h_f_0.19_orbitals.b59bd259-4941-4cec-bca5-e2795c35d8e0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b59bd259-4941-4cec-bca5-e2795c35d8e0",
+    "name": "h_f_0",
+    "category": "industrial",
+    "size": "19_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 618,
+        "t_count": 2984347040
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h_f_0.44_orbitals.daa86ad6-bda9-4d47-a50d-4ec34801bd82.json
+++ b/data/BOBQAT/resource_estimate.gsee.h_f_0.44_orbitals.daa86ad6-bda9-4d47-a50d-4ec34801bd82.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "daa86ad6-bda9-4d47-a50d-4ec34801bd82",
+    "name": "h_f_0",
+    "category": "industrial",
+    "size": "44_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1446,
+        "t_count": 162699937904
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.h_o_cl_0.37_orbitals.bd44e482-057d-42c3-a052-cbd952fa8025.json
+++ b/data/BOBQAT/resource_estimate.gsee.h_o_cl_0.37_orbitals.bd44e482-057d-42c3-a052-cbd952fa8025.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "bd44e482-057d-42c3-a052-cbd952fa8025",
+    "name": "h_o_cl_0",
+    "category": "industrial",
+    "size": "37_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 16,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 16,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1197,
+        "t_count": 126875338864
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.li2_0.28_orbitals.e7d3b8bd-ff6c-44f6-8a9e-b9b75396cee0.json
+++ b/data/BOBQAT/resource_estimate.gsee.li2_0.28_orbitals.e7d3b8bd-ff6c-44f6-8a9e-b9b75396cee0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "e7d3b8bd-ff6c-44f6-8a9e-b9b75396cee0",
+    "name": "li2_0",
+    "category": "industrial",
+    "size": "28_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 842,
+        "t_count": 7108986392
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.li2_0.60_orbitals.410cd417-988a-4f7f-99ad-93dda7eacdcb.json
+++ b/data/BOBQAT/resource_estimate.gsee.li2_0.60_orbitals.410cd417-988a-4f7f-99ad-93dda7eacdcb.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "410cd417-988a-4f7f-99ad-93dda7eacdcb",
+    "name": "li2_0",
+    "category": "industrial",
+    "size": "60_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1906,
+        "t_count": 161046464504
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.li_f_0.28_orbitals.80043b93-039c-4d5a-abcb-84b8f25f7abb.json
+++ b/data/BOBQAT/resource_estimate.gsee.li_f_0.28_orbitals.80043b93-039c-4d5a-abcb-84b8f25f7abb.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "80043b93-039c-4d5a-abcb-84b8f25f7abb",
+    "name": "li_f_0",
+    "category": "industrial",
+    "size": "28_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 874,
+        "t_count": 7030474264
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.li_f_0.60_orbitals.b80345ff-5df9-4fb3-86ab-0a25188b296d.json
+++ b/data/BOBQAT/resource_estimate.gsee.li_f_0.60_orbitals.b80345ff-5df9-4fb3-86ab-0a25188b296d.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b80345ff-5df9-4fb3-86ab-0a25188b296d",
+    "name": "li_f_0",
+    "category": "industrial",
+    "size": "60_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1973,
+        "t_count": 376263936256
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.li_h_0.19_orbitals.92917287-d937-410c-bb70-c1f34224fab7.json
+++ b/data/BOBQAT/resource_estimate.gsee.li_h_0.19_orbitals.92917287-d937-410c-bb70-c1f34224fab7.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "92917287-d937-410c-bb70-c1f34224fab7",
+    "name": "li_h_0",
+    "category": "industrial",
+    "size": "19_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 594,
+        "t_count": 1465763136
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.li_h_0.44_orbitals.d15db194-aa2d-4de9-8f86-fcffeb82f38b.json
+++ b/data/BOBQAT/resource_estimate.gsee.li_h_0.44_orbitals.d15db194-aa2d-4de9-8f86-fcffeb82f38b.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "d15db194-aa2d-4de9-8f86-fcffeb82f38b",
+    "name": "li_h_0",
+    "category": "industrial",
+    "size": "44_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1393,
+        "t_count": 84899399672
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.mn_mono.14_orbitals.1ade03f3-06b1-4e95-b271-fea5a6343829.json
+++ b/data/BOBQAT/resource_estimate.gsee.mn_mono.14_orbitals.1ade03f3-06b1-4e95-b271-fea5a6343829.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "1ade03f3-06b1-4e95-b271-fea5a6343829",
+    "name": "mn_mono",
+    "category": "industrial",
+    "size": "14_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.216679485,
+    "value_ci": [
+        0.163054421,
+        0.163054421
+    ],
+    "circuit_repetitions_per_calculation": 34,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 34,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 468,
+        "t_count": 4324132096
+    },
+    "value_per_t_gate": 1.4738046590452183e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.mn_mono.14_orbitals.590c2f0b-964b-4d09-96ad-101a9be59cab.json
+++ b/data/BOBQAT/resource_estimate.gsee.mn_mono.14_orbitals.590c2f0b-964b-4d09-96ad-101a9be59cab.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "590c2f0b-964b-4d09-96ad-101a9be59cab",
+    "name": "mn_mono",
+    "category": "industrial",
+    "size": "14_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.049623203,
+    "value_ci": [
+        0.035031302,
+        0.035031302
+    ],
+    "circuit_repetitions_per_calculation": 151,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 151,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 469,
+        "t_count": 8640922960
+    },
+    "value_per_t_gate": 3.803187286415855e-14
+}

--- a/data/BOBQAT/resource_estimate.gsee.mn_mono.14_orbitals.a9c90f98-6557-44d2-9ca0-0c9122f4080c.json
+++ b/data/BOBQAT/resource_estimate.gsee.mn_mono.14_orbitals.a9c90f98-6557-44d2-9ca0-0c9122f4080c.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "a9c90f98-6557-44d2-9ca0-0c9122f4080c",
+    "name": "mn_mono",
+    "category": "industrial",
+    "size": "14_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.051587712,
+    "value_ci": [
+        0.043766067,
+        0.043766067
+    ],
+    "circuit_repetitions_per_calculation": 108,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 108,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 468,
+        "t_count": 4346676480
+    },
+    "value_per_t_gate": 1.0989177644065197e-13
+}

--- a/data/BOBQAT/resource_estimate.gsee.mn_mono.14_orbitals.de3ea361-c2d3-4ab6-add4-ccd43cea6aa8.json
+++ b/data/BOBQAT/resource_estimate.gsee.mn_mono.14_orbitals.de3ea361-c2d3-4ab6-add4-ccd43cea6aa8.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "de3ea361-c2d3-4ab6-add4-ccd43cea6aa8",
+    "name": "mn_mono",
+    "category": "industrial",
+    "size": "14_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.03001084,
+    "value_ci": [
+        0.023027308,
+        0.023027308
+    ],
+    "circuit_repetitions_per_calculation": 15,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 15,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 467,
+        "t_count": 2119074992
+    },
+    "value_per_t_gate": 9.441490623124992e-13
+}

--- a/data/BOBQAT/resource_estimate.gsee.mn_mono.30_orbitals.6c39d3a7-c71a-4049-a8c7-3a3a4b61d8da.json
+++ b/data/BOBQAT/resource_estimate.gsee.mn_mono.30_orbitals.6c39d3a7-c71a-4049-a8c7-3a3a4b61d8da.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "6c39d3a7-c71a-4049-a8c7-3a3a4b61d8da",
+    "name": "mn_mono",
+    "category": "industrial",
+    "size": "30_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 26.07488744,
+    "value_ci": [
+        17.97034674,
+        17.97034674
+    ],
+    "circuit_repetitions_per_calculation": 78,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 78,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 929,
+        "t_count": 56690345704
+    },
+    "value_per_t_gate": 5.8968317191680384e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.mn_mono.31_orbitals.6e617348-d0b3-4b6d-9923-ea54ba5cf751.json
+++ b/data/BOBQAT/resource_estimate.gsee.mn_mono.31_orbitals.6e617348-d0b3-4b6d-9923-ea54ba5cf751.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "6e617348-d0b3-4b6d-9923-ea54ba5cf751",
+    "name": "mn_mono",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 2.112505666,
+    "value_ci": [
+        1.644077649,
+        1.644077649
+    ],
+    "circuit_repetitions_per_calculation": 104,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 104,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 955,
+        "t_count": 62324868840
+    },
+    "value_per_t_gate": 3.259141151650955e-13
+}

--- a/data/BOBQAT/resource_estimate.gsee.mn_mono.31_orbitals.a16168e2-98cd-430d-a180-84f64b4d5e75.json
+++ b/data/BOBQAT/resource_estimate.gsee.mn_mono.31_orbitals.a16168e2-98cd-430d-a180-84f64b4d5e75.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "a16168e2-98cd-430d-a180-84f64b4d5e75",
+    "name": "mn_mono",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 8.778415022,
+    "value_ci": [
+        6.718317517,
+        6.718317517
+    ],
+    "circuit_repetitions_per_calculation": 280,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 280,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 956,
+        "t_count": 124247082832
+    },
+    "value_per_t_gate": 2.5233173694564974e-13
+}

--- a/data/BOBQAT/resource_estimate.gsee.mn_mono.31_orbitals.ff0da1e2-2c76-4589-aefa-c13bb1a1ef8f.json
+++ b/data/BOBQAT/resource_estimate.gsee.mn_mono.31_orbitals.ff0da1e2-2c76-4589-aefa-c13bb1a1ef8f.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "ff0da1e2-2c76-4589-aefa-c13bb1a1ef8f",
+    "name": "mn_mono",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 46.93508218,
+    "value_ci": [
+        41.69050008,
+        41.69050008
+    ],
+    "circuit_repetitions_per_calculation": 41,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 41,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 955,
+        "t_count": 62350034664
+    },
+    "value_per_t_gate": 1.836018388955582e-11
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo2_n2.69_orbitals.79b74ad4-afa8-458f-87a3-a5ec339056c6.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo2_n2.69_orbitals.79b74ad4-afa8-458f-87a3-a5ec339056c6.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "79b74ad4-afa8-458f-87a3-a5ec339056c6",
+    "name": "mo2_n2",
+    "category": "industrial",
+    "size": "69_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 4581.658495,
+    "value_ci": [
+        4008.43553,
+        4008.43553
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 2176,
+        "t_count": 518492653832
+    },
+    "value_per_t_gate": 1.7672992900240902e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo2_n2.69_orbitals.e3a07092-d1e5-4867-a4d7-d0258f9df6db.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo2_n2.69_orbitals.e3a07092-d1e5-4867-a4d7-d0258f9df6db.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "e3a07092-d1e5-4867-a4d7-d0258f9df6db",
+    "name": "mo2_n2",
+    "category": "industrial",
+    "size": "69_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 3852.986008,
+    "value_ci": [
+        1836.192222,
+        1836.192222
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 2176,
+        "t_count": 510313761032
+    },
+    "value_per_t_gate": 1.2583715817657497e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo2_n2.70_orbitals.138733f0-08f5-4077-b848-813c8ec53c79.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo2_n2.70_orbitals.138733f0-08f5-4077-b848-813c8ec53c79.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "138733f0-08f5-4077-b848-813c8ec53c79",
+    "name": "mo2_n2",
+    "category": "industrial",
+    "size": "70_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 3706.27159,
+    "value_ci": [
+        850.2519236,
+        850.2519236
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 2205,
+        "t_count": 515478522120
+    },
+    "value_per_t_gate": 1.1983271953334021e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2.30_orbitals.35c1aee4-4ef3-4e18-bc2a-377cf45e8fa1.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2.30_orbitals.35c1aee4-4ef3-4e18-bc2a-377cf45e8fa1.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "35c1aee4-4ef3-4e18-bc2a-377cf45e8fa1",
+    "name": "mo_n2",
+    "category": "industrial",
+    "size": "30_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 7.149569211,
+    "value_ci": [
+        5.137244241,
+        5.137244241
+    ],
+    "circuit_repetitions_per_calculation": 19,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 19,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 896,
+        "t_count": 28274132608
+    },
+    "value_per_t_gate": 1.3308741300235366e-11
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2.31_orbitals.00ba4917-d66a-4335-819f-43390dfc9929.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2.31_orbitals.00ba4917-d66a-4335-819f-43390dfc9929.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "00ba4917-d66a-4335-819f-43390dfc9929",
+    "name": "mo_n2",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 4.730922554,
+    "value_ci": [
+        3.871832015,
+        3.871832015
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 953,
+        "t_count": 15581218328
+    },
+    "value_per_t_gate": 7.590745560471297e-11
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2.46_orbitals.b9cc699a-80f8-4280-9731-23dee4d5a6a5.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2.46_orbitals.b9cc699a-80f8-4280-9731-23dee4d5a6a5.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b9cc699a-80f8-4280-9731-23dee4d5a6a5",
+    "name": "mo_n2",
+    "category": "industrial",
+    "size": "46_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 372223.8466,
+    "value_ci": [
+        245874.0038,
+        245874.0038
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1452,
+        "t_count": 175247853560
+    },
+    "value_per_t_gate": 3.5399753267406963e-07
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2.46_orbitals.dfd78a05-437d-4667-88d7-7e2a3384b816.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2.46_orbitals.dfd78a05-437d-4667-88d7-7e2a3384b816.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "dfd78a05-437d-4667-88d7-7e2a3384b816",
+    "name": "mo_n2",
+    "category": "industrial",
+    "size": "46_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 135930.6772,
+    "value_ci": [
+        115293.0646,
+        115293.0646
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1452,
+        "t_count": 161024968696
+    },
+    "value_per_t_gate": 1.2059414343429678e-07
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.25_orbitals.09b81c3d-aee1-4bc3-98ce-a72da477b108.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.25_orbitals.09b81c3d-aee1-4bc3-98ce-a72da477b108.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "09b81c3d-aee1-4bc3-98ce-a72da477b108",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "25_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.156030169,
+    "value_ci": [
+        0.129902777,
+        0.129902777
+    ],
+    "circuit_repetitions_per_calculation": 51,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 51,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 768,
+        "t_count": 17324115584
+    },
+    "value_per_t_gate": 1.7659863001935583e-13
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.31_orbitals.3fa3940d-8a68-44ae-9223-7346404651e6.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.31_orbitals.3fa3940d-8a68-44ae-9223-7346404651e6.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "3fa3940d-8a68-44ae-9223-7346404651e6",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 13.84351344,
+    "value_ci": [
+        13.05515391,
+        13.05515391
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 953,
+        "t_count": 15579383320
+    },
+    "value_per_t_gate": 2.2214475944995235e-10
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.31_orbitals.4c240146-6b8b-4fa5-88e4-41cbd39c8ac3.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.31_orbitals.4c240146-6b8b-4fa5-88e4-41cbd39c8ac3.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "4c240146-6b8b-4fa5-88e4-41cbd39c8ac3",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 3.101110575,
+    "value_ci": [
+        2.388644777,
+        2.388644777
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 953,
+        "t_count": 15580169752
+    },
+    "value_per_t_gate": 4.976053894730376e-11
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.31_orbitals.b628f4be-582f-4f23-96eb-c8b9e0005e4a.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.31_orbitals.b628f4be-582f-4f23-96eb-c8b9e0005e4a.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b628f4be-582f-4f23-96eb-c8b9e0005e4a",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 4.182479204,
+    "value_ci": [
+        3.534725986,
+        3.534725986
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 951,
+        "t_count": 15354594840
+    },
+    "value_per_t_gate": 6.809816943369116e-11
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.31_orbitals.b900c4a3-fe87-4df7-96b7-2767ccdc1d56.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.31_orbitals.b900c4a3-fe87-4df7-96b7-2767ccdc1d56.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b900c4a3-fe87-4df7-96b7-2767ccdc1d56",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 33.8081016,
+    "value_ci": [
+        30.92507521,
+        30.92507521
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 953,
+        "t_count": 15575189016
+    },
+    "value_per_t_gate": 5.426595716634608e-10
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.39_orbitals.87d59f7c-e397-42dc-aa6e-00200d8697aa.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.39_orbitals.87d59f7c-e397-42dc-aa6e-00200d8697aa.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "87d59f7c-e397-42dc-aa6e-00200d8697aa",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "39_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 34.45587084,
+    "value_ci": [
+        27.36835313,
+        27.36835313
+    ],
+    "circuit_repetitions_per_calculation": 90,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 90,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1172,
+        "t_count": 236289001584
+    },
+    "value_per_t_gate": 1.62023203266714e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.45_orbitals.7fc4c1d7-3469-40a3-9cd8-4354b6acf01d.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.45_orbitals.7fc4c1d7-3469-40a3-9cd8-4354b6acf01d.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "7fc4c1d7-3469-40a3-9cd8-4354b6acf01d",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "45_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 16873.5217,
+    "value_ci": [
+        11841.93532,
+        11841.93532
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1374,
+        "t_count": 88178100096
+    },
+    "value_per_t_gate": 4.7839320879077976e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.45_orbitals.c436c481-00d1-49ec-8d0e-0a5e83a8df19.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.45_orbitals.c436c481-00d1-49ec-8d0e-0a5e83a8df19.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "c436c481-00d1-49ec-8d0e-0a5e83a8df19",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "45_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 168.5772656,
+    "value_ci": [
+        102.9181618,
+        102.9181618
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1374,
+        "t_count": 83618891648
+    },
+    "value_per_t_gate": 4.0320377914033745e-10
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.45_orbitals.c582e543-075c-4fa1-b189-5e7455286d82.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.45_orbitals.c582e543-075c-4fa1-b189-5e7455286d82.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "c582e543-075c-4fa1-b189-5e7455286d82",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "45_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 887.7835663,
+    "value_ci": [
+        730.0479454,
+        730.0479454
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1374,
+        "t_count": 86539175808
+    },
+    "value_per_t_gate": 2.0517495296458094e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.45_orbitals.eadd62e9-ee3d-4193-94de-7735a529edce.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.45_orbitals.eadd62e9-ee3d-4193-94de-7735a529edce.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "eadd62e9-ee3d-4193-94de-7735a529edce",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "45_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 1149.297529,
+    "value_ci": [
+        1073.266581,
+        1073.266581
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1374,
+        "t_count": 88023959424
+    },
+    "value_per_t_gate": 3.2641610776220107e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.55_orbitals.349e9cbe-d675-411f-b6b8-be846c27902c.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.55_orbitals.349e9cbe-d675-411f-b6b8-be846c27902c.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "349e9cbe-d675-411f-b6b8-be846c27902c",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "55_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 38960.83337,
+    "value_ci": [
+        30261.44519,
+        30261.44519
+    ],
+    "circuit_repetitions_per_calculation": 106,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 106,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1709,
+        "t_count": 1010077010304
+    },
+    "value_per_t_gate": 3.63888127383308e-10
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.55_orbitals.aaae8d93-cb88-41ee-8f11-c70cc9b0d7fb.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.55_orbitals.aaae8d93-cb88-41ee-8f11-c70cc9b0d7fb.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "aaae8d93-cb88-41ee-8f11-c70cc9b0d7fb",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "55_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 313653.9546,
+    "value_ci": [
+        168760.6728,
+        168760.6728
+    ],
+    "circuit_repetitions_per_calculation": 124,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 124,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1709,
+        "t_count": 1154667252096
+    },
+    "value_per_t_gate": 2.190646154738395e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.55_orbitals.db75bf65-181b-40c2-b978-26453437c2b0.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.55_orbitals.db75bf65-181b-40c2-b978-26453437c2b0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "db75bf65-181b-40c2-b978-26453437c2b0",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "55_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 391626.1177,
+    "value_ci": [
+        254510.8539,
+        254510.8539
+    ],
+    "circuit_repetitions_per_calculation": 31,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 31,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1708,
+        "t_count": 594872109312
+    },
+    "value_per_t_gate": 2.1236666458574717e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.69_orbitals.3eccbccf-e84a-44b9-b775-cef772cd84f0.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.69_orbitals.3eccbccf-e84a-44b9-b775-cef772cd84f0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "3eccbccf-e84a-44b9-b775-cef772cd84f0",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "69_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 432962.4747,
+    "value_ci": [
+        372511.4479,
+        372511.4479
+    ],
+    "circuit_repetitions_per_calculation": 189,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 189,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 2174,
+        "t_count": 3826493950624
+    },
+    "value_per_t_gate": 5.986698983467292e-10
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.69_orbitals.ab482d50-9a85-48d9-aa17-83dcbb38614b.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.69_orbitals.ab482d50-9a85-48d9-aa17-83dcbb38614b.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "ab482d50-9a85-48d9-aa17-83dcbb38614b",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "69_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 2097859.259,
+    "value_ci": [
+        1370688.418,
+        1370688.418
+    ],
+    "circuit_repetitions_per_calculation": 35,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 35,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 2180,
+        "t_count": 2132561889968
+    },
+    "value_per_t_gate": 2.8106493065168666e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.70_orbitals.5547bb48-fac6-4426-91ad-c4853ce421aa.json
+++ b/data/BOBQAT/resource_estimate.gsee.mo_n2_pincer.70_orbitals.5547bb48-fac6-4426-91ad-c4853ce421aa.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "5547bb48-fac6-4426-91ad-c4853ce421aa",
+    "name": "mo_n2_pincer",
+    "category": "industrial",
+    "size": "70_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 5348581.195,
+    "value_ci": [
+        4445614.191,
+        4445614.191
+    ],
+    "circuit_repetitions_per_calculation": 269,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 269,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 2208,
+        "t_count": 4284570667680
+    },
+    "value_per_t_gate": 4.640652007069778e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.n2_0.28_orbitals.b9c35349-927d-47d5-8e0c-e054bbf4e4e0.json
+++ b/data/BOBQAT/resource_estimate.gsee.n2_0.28_orbitals.b9c35349-927d-47d5-8e0c-e054bbf4e4e0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b9c35349-927d-47d5-8e0c-e054bbf4e4e0",
+    "name": "n2_0",
+    "category": "industrial",
+    "size": "28_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 23,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 23,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 908,
+        "t_count": 29639706344
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.n2_0.60_orbitals.666185aa-b65d-4f73-8846-ae9693388d9d.json
+++ b/data/BOBQAT/resource_estimate.gsee.n2_0.60_orbitals.666185aa-b65d-4f73-8846-ae9693388d9d.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "666185aa-b65d-4f73-8846-ae9693388d9d",
+    "name": "n2_0",
+    "category": "industrial",
+    "size": "60_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 23,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 23,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1977,
+        "t_count": 1505760381440
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.n2_h4_0.48_orbitals.828c931b-4d5a-486e-ba26-abb293c1ccef.json
+++ b/data/BOBQAT/resource_estimate.gsee.n2_h4_0.48_orbitals.828c931b-4d5a-486e-ba26-abb293c1ccef.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "828c931b-4d5a-486e-ba26-abb293c1ccef",
+    "name": "n2_h4_0",
+    "category": "industrial",
+    "size": "48_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 34,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 34,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1562,
+        "t_count": 614230132968
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.n_h3_0.29_orbitals.77c3a92c-066c-4043-a4a1-5e8324014d0b.json
+++ b/data/BOBQAT/resource_estimate.gsee.n_h3_0.29_orbitals.77c3a92c-066c-4043-a4a1-5e8324014d0b.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "77c3a92c-066c-4043-a4a1-5e8324014d0b",
+    "name": "n_h3_0",
+    "category": "industrial",
+    "size": "29_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 10,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 10,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 936,
+        "t_count": 44159862504
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.na2_0.36_orbitals.4fb7e994-8e7a-4acd-86d4-bb52db824cfc.json
+++ b/data/BOBQAT/resource_estimate.gsee.na2_0.36_orbitals.4fb7e994-8e7a-4acd-86d4-bb52db824cfc.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "4fb7e994-8e7a-4acd-86d4-bb52db824cfc",
+    "name": "na2_0",
+    "category": "industrial",
+    "size": "36_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1125,
+        "t_count": 26684491520
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.na2_0.68_orbitals.620e9ff4-07bf-4767-9237-d39aa659b8e5.json
+++ b/data/BOBQAT/resource_estimate.gsee.na2_0.68_orbitals.620e9ff4-07bf-4767-9237-d39aa659b8e5.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "620e9ff4-07bf-4767-9237-d39aa659b8e5",
+    "name": "na2_0",
+    "category": "industrial",
+    "size": "68_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2144,
+        "t_count": 479596906896
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.na_cl_0.36_orbitals.da831b60-89ce-4c01-96f9-c9f8a4512aab.json
+++ b/data/BOBQAT/resource_estimate.gsee.na_cl_0.36_orbitals.da831b60-89ce-4c01-96f9-c9f8a4512aab.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "da831b60-89ce-4c01-96f9-c9f8a4512aab",
+    "name": "na_cl_0",
+    "category": "industrial",
+    "size": "36_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1127,
+        "t_count": 28096136960
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.na_cl_0.68_orbitals.01ec60f7-d38a-4c33-a498-659a388e10ee.json
+++ b/data/BOBQAT/resource_estimate.gsee.na_cl_0.68_orbitals.01ec60f7-d38a-4c33-a498-659a388e10ee.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "01ec60f7-d38a-4c33-a498-659a388e10ee",
+    "name": "na_cl_0",
+    "category": "industrial",
+    "size": "68_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2217,
+        "t_count": 590059145616
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.ozone.15_orbitals.b4968ccd-6711-4173-8f80-f16094b3e0cd.json
+++ b/data/BOBQAT/resource_estimate.gsee.ozone.15_orbitals.b4968ccd-6711-4173-8f80-f16094b3e0cd.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b4968ccd-6711-4173-8f80-f16094b3e0cd",
+    "name": "ozone",
+    "category": "industrial",
+    "size": "15_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 490,
+        "t_count": 1001931872
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.ozone.15_orbitals.e0de65ed-e45e-46e0-a57b-c6ad4efbdafe.json
+++ b/data/BOBQAT/resource_estimate.gsee.ozone.15_orbitals.e0de65ed-e45e-46e0-a57b-c6ad4efbdafe.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "e0de65ed-e45e-46e0-a57b-c6ad4efbdafe",
+    "name": "ozone",
+    "category": "industrial",
+    "size": "15_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 490,
+        "t_count": 1012941920
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.ozone.42_orbitals.881f5275-83eb-470c-80fe-eebb7ced30e9.json
+++ b/data/BOBQAT/resource_estimate.gsee.ozone.42_orbitals.881f5275-83eb-470c-80fe-eebb7ced30e9.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "881f5275-83eb-470c-80fe-eebb7ced30e9",
+    "name": "ozone",
+    "category": "industrial",
+    "size": "42_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1341,
+        "t_count": 100754393080
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.ozone.42_orbitals.a2ad41b8-37bb-44e1-be3e-df1052952e9c.json
+++ b/data/BOBQAT/resource_estimate.gsee.ozone.42_orbitals.a2ad41b8-37bb-44e1-be3e-df1052952e9c.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "a2ad41b8-37bb-44e1-be3e-df1052952e9c",
+    "name": "ozone",
+    "category": "industrial",
+    "size": "42_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 6,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 6,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1342,
+        "t_count": 189685041264
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.p2_0.36_orbitals.084acde0-d1c7-4721-aa45-acb4832e0998.json
+++ b/data/BOBQAT/resource_estimate.gsee.p2_0.36_orbitals.084acde0-d1c7-4721-aa45-acb4832e0998.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "084acde0-d1c7-4721-aa45-acb4832e0998",
+    "name": "p2_0",
+    "category": "industrial",
+    "size": "36_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 55,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 55,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1168,
+        "t_count": 227239528528
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.p2_0.68_orbitals.23a06c81-be81-4f88-98ab-9e7030c909ef.json
+++ b/data/BOBQAT/resource_estimate.gsee.p2_0.68_orbitals.23a06c81-be81-4f88-98ab-9e7030c909ef.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "23a06c81-be81-4f88-98ab-9e7030c909ef",
+    "name": "p2_0",
+    "category": "industrial",
+    "size": "68_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 49,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 49,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2221,
+        "t_count": 2720518900384
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.p_h3_0.33_orbitals.af399f2b-a4f8-4fec-aca2-7c126ed989a5.json
+++ b/data/BOBQAT/resource_estimate.gsee.p_h3_0.33_orbitals.af399f2b-a4f8-4fec-aca2-7c126ed989a5.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "af399f2b-a4f8-4fec-aca2-7c126ed989a5",
+    "name": "p_h3_0",
+    "category": "industrial",
+    "size": "33_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 14,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 14,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1047,
+        "t_count": 58982008688
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0001.14_orbitals.be3812d3-5975-4736-8a23-96d64e50e66a.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0001.14_orbitals.be3812d3-5975-4736-8a23-96d64e50e66a.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "be3812d3-5975-4736-8a23-96d64e50e66a",
+    "name": "planted_solution_0001",
+    "category": "industrial",
+    "size": "14_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 11,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 11,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 517,
+        "t_count": 8071677200
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0002.69_orbitals.0deae366-42de-4081-914d-db85c6b47168.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0002.69_orbitals.0deae366-42de-4081-914d-db85c6b47168.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "0deae366-42de-4081-914d-db85c6b47168",
+    "name": "planted_solution_0002",
+    "category": "industrial",
+    "size": "69_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 1062,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 1062,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2324,
+        "t_count": 10654463298432
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0003.31_orbitals.472bbfb1-c081-4df6-b966-32ce1194ab8c.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0003.31_orbitals.472bbfb1-c081-4df6-b966-32ce1194ab8c.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "472bbfb1-c081-4df6-b966-32ce1194ab8c",
+    "name": "planted_solution_0003",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1052,
+        "t_count": 20010239536
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0004.70_orbitals.c9809448-2f3d-40d4-858d-6288a4703af4.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0004.70_orbitals.c9809448-2f3d-40d4-858d-6288a4703af4.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "c9809448-2f3d-40d4-858d-6288a4703af4",
+    "name": "planted_solution_0004",
+    "category": "industrial",
+    "size": "70_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2421,
+        "t_count": 717735070080
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0005.14_orbitals.a41a284c-7baa-438e-9323-532091c7a78f.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0005.14_orbitals.a41a284c-7baa-438e-9323-532091c7a78f.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "a41a284c-7baa-438e-9323-532091c7a78f",
+    "name": "planted_solution_0005",
+    "category": "industrial",
+    "size": "14_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 2,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 518,
+        "t_count": 4181591240
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0006.14_orbitals.d28f02ba-d43f-4df9-a01a-f1e8ac326e08.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0006.14_orbitals.d28f02ba-d43f-4df9-a01a-f1e8ac326e08.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "d28f02ba-d43f-4df9-a01a-f1e8ac326e08",
+    "name": "planted_solution_0006",
+    "category": "industrial",
+    "size": "14_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 516,
+        "t_count": 3959293128
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0007.31_orbitals.d3c058ec-9b13-4a9a-aba0-d3f19091c47b.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0007.31_orbitals.d3c058ec-9b13-4a9a-aba0-d3f19091c47b.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "d3c058ec-9b13-4a9a-aba0-d3f19091c47b",
+    "name": "planted_solution_0007",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1049,
+        "t_count": 18988926512
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0008.14_orbitals.af56de36-35aa-44b9-8eb7-b9c1e8f7d0f3.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0008.14_orbitals.af56de36-35aa-44b9-8eb7-b9c1e8f7d0f3.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "af56de36-35aa-44b9-8eb7-b9c1e8f7d0f3",
+    "name": "planted_solution_0008",
+    "category": "industrial",
+    "size": "14_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 7,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 7,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 516,
+        "t_count": 4042130632
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0009.69_orbitals.8f373cb0-952d-48c6-a871-8a10e52e7c19.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0009.69_orbitals.8f373cb0-952d-48c6-a871-8a10e52e7c19.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "8f373cb0-952d-48c6-a871-8a10e52e7c19",
+    "name": "planted_solution_0009",
+    "category": "industrial",
+    "size": "69_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2320,
+        "t_count": 720211806592
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0010.30_orbitals.7cc1ed5c-0dcb-4315-9e51-2ae94b5cdd02.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0010.30_orbitals.7cc1ed5c-0dcb-4315-9e51-2ae94b5cdd02.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "7cc1ed5c-0dcb-4315-9e51-2ae94b5cdd02",
+    "name": "planted_solution_0010",
+    "category": "industrial",
+    "size": "30_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 2,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1025,
+        "t_count": 19212273200
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.planted_solution_0011.31_orbitals.0021e256-8e13-42db-839d-e9155e8af82c.json
+++ b/data/BOBQAT/resource_estimate.gsee.planted_solution_0011.31_orbitals.0021e256-8e13-42db-839d-e9155e8af82c.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "0021e256-8e13-42db-839d-e9155e8af82c",
+    "name": "planted_solution_0011",
+    "category": "industrial",
+    "size": "31_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 2,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1051,
+        "t_count": 18905040432
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_macho.12_orbitals.dcf2b441-b297-4a89-ae18-5778ec2d674d.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_macho.12_orbitals.dcf2b441-b297-4a89-ae18-5778ec2d674d.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "dcf2b441-b297-4a89-ae18-5778ec2d674d",
+    "name": "ru_macho",
+    "category": "industrial",
+    "size": "12_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.001894704,
+    "value_ci": [
+        0.001330711,
+        0.001330711
+    ],
+    "circuit_repetitions_per_calculation": 2,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 383,
+        "t_count": 199971776
+    },
+    "value_per_t_gate": 4.7374285459164e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_macho.14_orbitals.28bd4997-c04c-4914-9984-0101713041fe.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_macho.14_orbitals.28bd4997-c04c-4914-9984-0101713041fe.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "28bd4997-c04c-4914-9984-0101713041fe",
+    "name": "ru_macho",
+    "category": "industrial",
+    "size": "14_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.009471048,
+    "value_ci": [
+        0.004235272,
+        0.004235272
+    ],
+    "circuit_repetitions_per_calculation": 2,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 432,
+        "t_count": 268506048
+    },
+    "value_per_t_gate": 1.7636563627795825e-11
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_macho.21_orbitals.89253c8f-0f01-4046-a138-1bada22f0a6a.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_macho.21_orbitals.89253c8f-0f01-4046-a138-1bada22f0a6a.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "89253c8f-0f01-4046-a138-1bada22f0a6a",
+    "name": "ru_macho",
+    "category": "industrial",
+    "size": "21_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.033479648,
+    "value_ci": [
+        0.02633265,
+        0.02633265
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 643,
+        "t_count": 2787362112
+    },
+    "value_per_t_gate": 4.003743402632097e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_macho.23_orbitals.68db6781-dd54-43c4-b667-7b754c4d5cdb.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_macho.23_orbitals.68db6781-dd54-43c4-b667-7b754c4d5cdb.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "68db6781-dd54-43c4-b667-7b754c4d5cdb",
+    "name": "ru_macho",
+    "category": "industrial",
+    "size": "23_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.063567295,
+    "value_ci": [
+        0.055519694,
+        0.055519694
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 693,
+        "t_count": 3484042672
+    },
+    "value_per_t_gate": 6.081756260800853e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_macho.33_orbitals.6346b7fe-a4a5-4b10-a79b-706d4339923e.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_macho.33_orbitals.6346b7fe-a4a5-4b10-a79b-706d4339923e.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "6346b7fe-a4a5-4b10-a79b-706d4339923e",
+    "name": "ru_macho",
+    "category": "industrial",
+    "size": "33_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 124.2353829,
+    "value_ci": [
+        100.4889517,
+        100.4889517
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1013,
+        "t_count": 18508777224
+    },
+    "value_per_t_gate": 1.678060379090119e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_macho.42_orbitals.842d2152-2f91-4dce-b088-7ed26afb2381.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_macho.42_orbitals.842d2152-2f91-4dce-b088-7ed26afb2381.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "842d2152-2f91-4dce-b088-7ed26afb2381",
+    "name": "ru_macho",
+    "category": "industrial",
+    "size": "42_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 3737.403147,
+    "value_ci": [
+        3271.381861,
+        3271.381861
+    ],
+    "circuit_repetitions_per_calculation": 4,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 4,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1293,
+        "t_count": 72133052288
+    },
+    "value_per_t_gate": 1.2953157493176507e-08
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_macho.45_orbitals.d3ecd428-ee03-4d8b-aa14-af4d935781ed.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_macho.45_orbitals.d3ecd428-ee03-4d8b-aa14-af4d935781ed.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "d3ecd428-ee03-4d8b-aa14-af4d935781ed",
+    "name": "ru_macho",
+    "category": "industrial",
+    "size": "45_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 2085.253184,
+    "value_ci": [
+        1805.041988,
+        1805.041988
+    ],
+    "circuit_repetitions_per_calculation": 5,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 5,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1376,
+        "t_count": 86421997440
+    },
+    "value_per_t_gate": 4.825746327947868e-09
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_macho.6_orbitals.4357d5bb-ed2b-466a-947b-e868afb81d3d.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_macho.6_orbitals.4357d5bb-ed2b-466a-947b-e868afb81d3d.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "4357d5bb-ed2b-466a-947b-e868afb81d3d",
+    "name": "ru_macho",
+    "category": "industrial",
+    "size": "6_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.000253156,
+    "value_ci": [
+        0.000129616,
+        0.000129616
+    ],
+    "circuit_repetitions_per_calculation": 2,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 211,
+        "t_count": 16784944
+    },
+    "value_per_t_gate": 7.541163080436849e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_macho.9_orbitals.b164af91-a758-445c-8e78-610ffd2ad795.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_macho.9_orbitals.b164af91-a758-445c-8e78-610ffd2ad795.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "b164af91-a758-445c-8e78-610ffd2ad795",
+    "name": "ru_macho",
+    "category": "industrial",
+    "size": "9_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.003732088,
+    "value_ci": [
+        0.002621165,
+        0.002621165
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 305,
+        "t_count": 127562592
+    },
+    "value_per_t_gate": 9.752305231719762e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_mono.10_orbitals.d937e005-3688-4138-9465-426798087395.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_mono.10_orbitals.d937e005-3688-4138-9465-426798087395.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "d937e005-3688-4138-9465-426798087395",
+    "name": "ru_mono",
+    "category": "industrial",
+    "size": "10_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.007203809,
+    "value_ci": [
+        0.002840969,
+        0.002840969
+    ],
+    "circuit_repetitions_per_calculation": 8,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 8,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 325,
+        "t_count": 269837224
+    },
+    "value_per_t_gate": 3.3371086155259294e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_mono.34_orbitals.a475af8e-cb0b-4533-906d-a6b8eda313e7.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_mono.34_orbitals.a475af8e-cb0b-4533-906d-a6b8eda313e7.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "a475af8e-cb0b-4533-906d-a6b8eda313e7",
+    "name": "ru_mono",
+    "category": "industrial",
+    "size": "34_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.232139321,
+    "value_ci": [
+        0.151470222,
+        0.151470222
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1039,
+        "t_count": 18332747528
+    },
+    "value_per_t_gate": 4.220849796163007e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_mono.34_orbitals.bc3520b5-bf25-4a43-892c-8d7e9a690fe2.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_mono.34_orbitals.bc3520b5-bf25-4a43-892c-8d7e9a690fe2.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "bc3520b5-bf25-4a43-892c-8d7e9a690fe2",
+    "name": "ru_mono",
+    "category": "industrial",
+    "size": "34_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 10.47278219,
+    "value_ci": [
+        9.52609622,
+        9.52609622
+    ],
+    "circuit_repetitions_per_calculation": 12,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 12,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1040,
+        "t_count": 39582107520
+    },
+    "value_per_t_gate": 2.204864530585426e-11
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_mono.36_orbitals.ace55695-1ca9-4153-8fd4-55ed6658cf8c.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_mono.36_orbitals.ace55695-1ca9-4153-8fd4-55ed6658cf8c.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "ace55695-1ca9-4153-8fd4-55ed6658cf8c",
+    "name": "ru_mono",
+    "category": "industrial",
+    "size": "36_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 307.7303081,
+    "value_ci": [
+        269.3114425,
+        269.3114425
+    ],
+    "circuit_repetitions_per_calculation": 13,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 13,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 1092,
+        "t_count": 43199694720
+    },
+    "value_per_t_gate": 5.479567000407373e-10
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_mono.9_orbitals.5509795a-90ce-45d6-b03d-db956a5da5b2.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_mono.9_orbitals.5509795a-90ce-45d6-b03d-db956a5da5b2.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "5509795a-90ce-45d6-b03d-db956a5da5b2",
+    "name": "ru_mono",
+    "category": "industrial",
+    "size": "9_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.001140956,
+    "value_ci": [
+        0.001140956,
+        0.001140956
+    ],
+    "circuit_repetitions_per_calculation": 3,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 3,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 300,
+        "t_count": 61791000
+    },
+    "value_per_t_gate": 6.154920080054809e-12
+}

--- a/data/BOBQAT/resource_estimate.gsee.ru_mono.9_orbitals.dab492c3-27fe-4ac3-8c98-de2563caf66c.json
+++ b/data/BOBQAT/resource_estimate.gsee.ru_mono.9_orbitals.dab492c3-27fe-4ac3-8c98-de2563caf66c.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "dab492c3-27fe-4ac3-8c98-de2563caf66c",
+    "name": "ru_mono",
+    "category": "industrial",
+    "size": "9_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.001533895,
+    "value_ci": [
+        0.000965952,
+        0.000965952
+    ],
+    "circuit_repetitions_per_calculation": 2,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 2,
+    "runtime_requirement": 172800,
+    "logical-abstract": {
+        "num_qubits": 291,
+        "t_count": 58237720
+    },
+    "value_per_t_gate": 1.3169256969537955e-11
+}

--- a/data/BOBQAT/resource_estimate.gsee.s_o2_0.46_orbitals.c7cd47fa-1bbd-4859-a0c8-3fd5c287c6db.json
+++ b/data/BOBQAT/resource_estimate.gsee.s_o2_0.46_orbitals.c7cd47fa-1bbd-4859-a0c8-3fd5c287c6db.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "c7cd47fa-1bbd-4859-a0c8-3fd5c287c6db",
+    "name": "s_o2_0",
+    "category": "industrial",
+    "size": "46_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 33,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 33,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1455,
+        "t_count": 444675393768
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.si2_h6_0.66_orbitals.109f95c5-8561-458c-8f41-72be596b87e6.json
+++ b/data/BOBQAT/resource_estimate.gsee.si2_h6_0.66_orbitals.109f95c5-8561-458c-8f41-72be596b87e6.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "109f95c5-8561-458c-8f41-72be596b87e6",
+    "name": "si2_h6_0",
+    "category": "industrial",
+    "size": "66_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 25,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 25,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2090,
+        "t_count": 1400564615704
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.si_h2_singlet_0.28_orbitals.240f7830-f4e1-4301-b0af-ab8936851796.json
+++ b/data/BOBQAT/resource_estimate.gsee.si_h2_singlet_0.28_orbitals.240f7830-f4e1-4301-b0af-ab8936851796.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "240f7830-f4e1-4301-b0af-ab8936851796",
+    "name": "si_h2_singlet_0",
+    "category": "industrial",
+    "size": "28_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 8,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 8,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 875,
+        "t_count": 14770833024
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.si_h2_singlet_0.62_orbitals.5e1dcd34-1373-4f34-b9df-d738a8cf4db6.json
+++ b/data/BOBQAT/resource_estimate.gsee.si_h2_singlet_0.62_orbitals.5e1dcd34-1373-4f34-b9df-d738a8cf4db6.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "5e1dcd34-1373-4f34-b9df-d738a8cf4db6",
+    "name": "si_h2_singlet_0",
+    "category": "industrial",
+    "size": "62_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 8,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 8,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2033,
+        "t_count": 427717560576
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.si_h4_0.38_orbitals.2eaee11d-c1a0-4d2b-b29b-a38e658572f2.json
+++ b/data/BOBQAT/resource_estimate.gsee.si_h4_0.38_orbitals.2eaee11d-c1a0-4d2b-b29b-a38e658572f2.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "2eaee11d-c1a0-4d2b-b29b-a38e658572f2",
+    "name": "si_h4_0",
+    "category": "industrial",
+    "size": "38_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 15,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 15,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1187,
+        "t_count": 83544639480
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.si_o_0.32_orbitals.88a6b9fd-e159-4059-9ee5-ba718fd624dc.json
+++ b/data/BOBQAT/resource_estimate.gsee.si_o_0.32_orbitals.88a6b9fd-e159-4059-9ee5-ba718fd624dc.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "88a6b9fd-e159-4059-9ee5-ba718fd624dc",
+    "name": "si_o_0",
+    "category": "industrial",
+    "size": "32_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 30,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 30,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 1020,
+        "t_count": 82620712784
+    },
+    "value_per_t_gate": 0.0
+}

--- a/data/BOBQAT/resource_estimate.gsee.si_o_0.64_orbitals.8aa559b0-3aae-4850-a2d7-14e037ce26c0.json
+++ b/data/BOBQAT/resource_estimate.gsee.si_o_0.64_orbitals.8aa559b0-3aae-4850-a2d7-14e037ce26c0.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rroodll/QB-Estimate-Reporting/main/schema/resource_estimate_schema.json",
+    "id": "8aa559b0-3aae-4850-a2d7-14e037ce26c0",
+    "name": "si_o_0",
+    "category": "industrial",
+    "size": "64_orbitals",
+    "task": "ground_state_energy_estimation",
+    "implementation": "Double factorized QPE resource estimates based on methodology of arXiv:2406.06335. Note that the truncation error is not included in the error bounds and that the SCF compute time is not included in the preprocessing time. Ground-state overlap is taken to be that estimated for the dominant CSF as estimated by DMRG and that this DMRG runtime is not included in the classical compute costs.",
+    "value": 0.0,
+    "value_ci": [
+        0.0,
+        0.0
+    ],
+    "circuit_repetitions_per_calculation": 23,
+    "calculation_repetitions": 1,
+    "total_circuit_repetitions": 23,
+    "runtime_requirement": 86400,
+    "logical-abstract": {
+        "num_qubits": 2095,
+        "t_count": 1944182589952
+    },
+    "value_per_t_gate": 0.0
+}


### PR DESCRIPTION
currently we are missing `t_counts` (REQUIRED) for `logical-compiled` and `physical` so we do not report those objects even though we have other data for them.